### PR TITLE
Switch to BCrypt for user passwords

### DIFF
--- a/src/main/java/com/tesis/aike/configuration/PasswordEncoderConfiguration.java
+++ b/src/main/java/com/tesis/aike/configuration/PasswordEncoderConfiguration.java
@@ -1,0 +1,14 @@
+package com.tesis.aike.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfiguration {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/tesis/aike/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/tesis/aike/service/impl/UserServiceImpl.java
@@ -8,7 +8,7 @@ import com.tesis.aike.model.entity.UsersEntity;
 import com.tesis.aike.repository.RolesRepository;
 import com.tesis.aike.repository.UsersRepository;
 import com.tesis.aike.service.UserService;
-import com.tesis.aike.utils.PasswordEncryptor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -23,14 +23,17 @@ public class UserServiceImpl implements UserService {
     private final UsersRepository usersRepo;
     private final RolesRepository rolesRepo;
     private final UserMapper mapper;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     @Autowired
     public UserServiceImpl(UsersRepository usersRepo,
                            RolesRepository rolesRepo,
-                           UserMapper mapper) {
+                           UserMapper mapper,
+                           BCryptPasswordEncoder passwordEncoder) {
         this.usersRepo = usersRepo;
         this.rolesRepo = rolesRepo;
         this.mapper = mapper;
+        this.passwordEncoder = passwordEncoder;
     }
 
     private UserDTO toDTOWithRoleName(UsersEntity entity) {
@@ -45,7 +48,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public UserDTO create(UserDTO in) {
-        in.setPassword(PasswordEncryptor.encryptPassword(in.getPassword()));
+        in.setPassword(passwordEncoder.encode(in.getPassword()));
         UsersEntity saved = usersRepo.save(mapper.toEntity(in));
         return toDTOWithRoleName(saved);
     }
@@ -58,7 +61,7 @@ public class UserServiceImpl implements UserService {
         e.setDni(in.getDni());
         e.setRoleId(in.getRole().getId());
         if (in.getPassword() != null && !in.getPassword().isBlank())
-            e.setPassword(PasswordEncryptor.encryptPassword(in.getPassword()));
+            e.setPassword(passwordEncoder.encode(in.getPassword()));
         return toDTOWithRoleName(e);
     }
 

--- a/src/test/java/com/tesis/aike/service/UserServiceImplTest.java
+++ b/src/test/java/com/tesis/aike/service/UserServiceImplTest.java
@@ -1,0 +1,68 @@
+package com.tesis.aike.service;
+
+import com.tesis.aike.helper.mapper.UserMapper;
+import com.tesis.aike.model.dto.RoleDTO;
+import com.tesis.aike.model.dto.UserDTO;
+import com.tesis.aike.model.entity.RolesEntity;
+import com.tesis.aike.model.entity.UsersEntity;
+import com.tesis.aike.repository.RolesRepository;
+import com.tesis.aike.repository.UsersRepository;
+import com.tesis.aike.service.impl.UserServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UserServiceImplTest {
+
+    @Mock
+    private UsersRepository usersRepository;
+    @Mock
+    private RolesRepository rolesRepository;
+
+    private UserMapper mapper = Mappers.getMapper(UserMapper.class);
+    private BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+    private UserServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        service = new UserServiceImpl(usersRepository, rolesRepository, mapper, encoder);
+    }
+
+    @Test
+    void createEncodesPasswordWithBCrypt() {
+        UserDTO dto = new UserDTO();
+        dto.setName("Test");
+        dto.setEmail("test@example.com");
+        dto.setDni("123");
+        dto.setPassword("secret");
+        dto.setRole(new RoleDTO(1L, "ADMIN"));
+
+        when(usersRepository.save(any(UsersEntity.class))).thenAnswer(i -> i.getArgument(0));
+        RolesEntity roleEntity = new RolesEntity();
+        roleEntity.setId(1L);
+        roleEntity.setName("ADMIN");
+        when(rolesRepository.findById(1L)).thenReturn(Optional.of(roleEntity));
+
+        service.create(dto);
+
+        ArgumentCaptor<UsersEntity> captor = ArgumentCaptor.forClass(UsersEntity.class);
+        verify(usersRepository).save(captor.capture());
+
+        UsersEntity saved = captor.getValue();
+        assertNotEquals("secret", saved.getPassword());
+        assertTrue(encoder.matches("secret", saved.getPassword()));
+    }
+}


### PR DESCRIPTION
## Summary
- configure `BCryptPasswordEncoder` bean
- inject encoder into `UserServiceImpl`
- hash passwords with BCrypt when creating or updating users
- add unit test for password hashing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849f7ced128832ea0568dc1ef64a0d6