### PR TITLE
Fix QR token user claim

### DIFF
--- a/src/main/java/com/tesis/aike/service/impl/QRCodeServiceImpl.java
+++ b/src/main/java/com/tesis/aike/service/impl/QRCodeServiceImpl.java
@@ -50,7 +50,8 @@ public class QRCodeServiceImpl implements QRCodeService {
         try {
             Instant now = Instant.now();
             String jwt = Jwts.builder()
-                    .setSubject(userId.toString())
+                    .claim("s", userId.toString())
+                    .claim("r", "CLIENT")
                     .setExpiration(Date.from(now.plus(5, ChronoUnit.SECONDS)))
                     .signWith(jwtTokenUtil.getKey())
                     .compact();


### PR DESCRIPTION
## Summary
- ensure QR tokens include the custom `s` claim instead of standard `sub`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*
- `./mvnw -q test` *(fails: `Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_686f370c5510832e948819f62119415a