### PR TITLE
Improve AI responses with tour and product info

### DIFF
--- a/src/main/java/com/tesis/aike/helper/ConstantValues.java
+++ b/src/main/java/com/tesis/aike/helper/ConstantValues.java
@@ -27,6 +27,24 @@ public class ConstantValues {
                 Instrucción: Responde amablemente que tu función es ayudar con información sobre las "Cabañas Aike", como la disponibilidad y gestión de reservas.
                 No intentes responder la pregunta original del usuario. Guíalo de vuelta a los temas relevantes.
                 """;
+
+        // Información de productos
+        public static final String PRODUCTS_TEMPLATE = "Estos son los productos disponibles en la tienda:\n%s";
+        public static final String CONTEXT_PRODUCTS_PROMPT = "Contexto sobre los productos disponibles:\n%s\n\nPregunta del usuario: \"%s\"\n\nInstrucción: Responde utilizando únicamente la información del contexto.";
+        public static final String NO_PRODUCTS = "Actualmente no hay productos disponibles en la tienda.";
+        public static final String ERROR_PRODUCTS = "Lo siento, hubo un problema al obtener los productos.";
+
+        // Información de la cabaña reservada
+        public static final String USER_CABIN_TEMPLATE = "Información de tu cabaña:\nNombre: %s\nCapacidad: %d\nDescripción: %s";
+        public static final String CONTEXT_CABIN_PROMPT = "Contexto de la base de datos sobre la cabaña reservada por el usuario (ID reserva: %d):\n%s\n\nPregunta del usuario: \"%s\"\n\nInstrucción: Responde utilizando sólo la información del contexto.";
+        public static final String USER_NO_RESERVATION = "Según nuestros registros, no tienes una cabaña reservada.";
+        public static final String ERROR_CABIN_INFO = "Lo siento, hubo un problema al consultar la información de tu cabaña.";
+
+        // Información de recorridos turísticos
+        public static final String TOURS_TEMPLATE = "Estos son los recorridos recomendados para la cabaña %s:\n%s";
+        public static final String CONTEXT_TOURS_PROMPT = "Contexto sobre recorridos turísticos:\n%s\n\nPregunta del usuario: \"%s\"\n\nInstrucción: Responde utilizando sólo la información del contexto.";
+        public static final String NO_TOURS = "No hay recorridos turísticos registrados para tu cabaña.";
+        public static final String ERROR_TOURS = "Lo siento, hubo un problema al obtener los recorridos.";
     }
 
     public static class ReservationService {
@@ -53,7 +71,8 @@ public class ConstantValues {
 
         public static final String[] USER_RESERVATIONS = {
                 "mis reservas", "ver mis reservas", "reservas que hice", "mis reservaciones",
-                "estado de mis reservas", "consultar mis reservas", "consultar mis reservaciones"
+                "estado de mis reservas", "consultar mis reservas", "consultar mis reservaciones",
+                "informacion de mi reserva", "detalles de mi reserva"
         };
 
         public static final String[] RESERVATION_OWNERSHIP = {"mias", "mis", "mía", "mi"};
@@ -67,6 +86,12 @@ public class ConstantValues {
         public static final String[] SENSITIVE_DATA = {
                 "dni de", "correo de", "email de", "número de documento de"
         };
+
+        public static final String[] PRODUCTS = {"productos", "tienda", "que venden", "comprar"};
+
+        public static final String[] MY_CABIN = {"mi cabaña", "cabaña que reservé", "información de la cabaña"};
+
+        public static final String[] TOURS = {"recorridos", "tours", "actividades", "atracciones"};
     }
 
     public static class Security {

--- a/src/main/java/com/tesis/aike/service/TourService.java
+++ b/src/main/java/com/tesis/aike/service/TourService.java
@@ -1,0 +1,7 @@
+package com.tesis.aike.service;
+
+import java.util.List;
+
+public interface TourService {
+    List<String> getToursForCabin(String cabinName);
+}

--- a/src/main/java/com/tesis/aike/service/impl/TourServiceImpl.java
+++ b/src/main/java/com/tesis/aike/service/impl/TourServiceImpl.java
@@ -1,0 +1,32 @@
+package com.tesis.aike.service.impl;
+
+import com.tesis.aike.service.TourService;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class TourServiceImpl implements TourService {
+
+    private final Map<String, List<String>> toursByCabin = new HashMap<>();
+    private final List<String> defaultTours = List.of(
+            "Recorrido por el bosque y mirador",
+            "Visita guiada al lago cercano"
+    );
+
+    public TourServiceImpl() {
+        toursByCabin.put("Caba\u00f1a 1", List.of(
+                "Senderismo en el parque nacional",
+                "Excursi\u00f3n en kayak por el r\u00edo"
+        ));
+        toursByCabin.put("Caba\u00f1a 2", List.of(
+                "Cabalgata por los valles",
+                "Tour fotogr\u00e1fico al amanecer"
+        ));
+    }
+
+    @Override
+    public List<String> getToursForCabin(String cabinName) {
+        return toursByCabin.getOrDefault(cabinName, defaultTours);
+    }
+}

--- a/src/main/java/com/tesis/aike/utils/QueryDetector.java
+++ b/src/main/java/com/tesis/aike/utils/QueryDetector.java
@@ -24,6 +24,18 @@ public class QueryDetector {
                 && !containsAny(message, ConstantValues.QueryKeywords.RESERVATION_OWNERSHIP);
     }
 
+    public static boolean isProductsQuery(String message) {
+        return containsAny(message, ConstantValues.QueryKeywords.PRODUCTS);
+    }
+
+    public static boolean isMyCabinQuery(String message) {
+        return containsAny(message, ConstantValues.QueryKeywords.MY_CABIN);
+    }
+
+    public static boolean isTourQuery(String message) {
+        return containsAny(message, ConstantValues.QueryKeywords.TOURS);
+    }
+
     private static boolean containsAny(String text, String[] keywords) {
         if (text == null) return false;
         String lower = text.toLowerCase();


### PR DESCRIPTION
## Summary
- add simple `TourService` with canned tours
- extend AI logic with new prompts for cabin details, tours and shop products
- update constants and query keywords for new features

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6871917a1200832e8fc3c8a1652384a8