### PR TITLE
Add constants for product and tour errors

### DIFF
--- a/src/main/java/com/tesis/aike/helper/ConstantValues.java
+++ b/src/main/java/com/tesis/aike/helper/ConstantValues.java
@@ -82,5 +82,7 @@ public class ConstantValues {
         public static final String ERROR_CALL_OPENAI = "Error al llamar a la API OpenAI: {}";
         public static final String ERROR_SYSTEM_OPENAI = "Error al usar rol de sistema con OpenAI: {}";
         public static final String ERROR_AUTH_ID = "No se pudo obtener ID de usuario autenticado: {}";
+        public static final String ERROR_FETCH_PRODUCTS = "Error al obtener información de productos: {}";
+        public static final String ERROR_FETCH_TOURS = "Error al obtener información de tours: {}";
     }
 }


### PR DESCRIPTION
## Summary
- extend `ConstantValues` logging messages with errors for products and tours

## Testing
- `./mvnw -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871be28fc78832ea5d9e4c787de5622