### PR TITLE
Improve reservation replies

### DIFF
--- a/src/main/java/com/tesis/aike/controller/AikeIAController.java
+++ b/src/main/java/com/tesis/aike/controller/AikeIAController.java
@@ -30,8 +30,7 @@ public class    AikeIAController {
 
         String iaResponseText = chatGptService.promptResponse(prompt);
 
-        String[] lines = iaResponseText == null ? new String[0] : iaResponseText.split("\n");
-        ChatApiResponse apiResponse = new ChatApiResponse(iaResponseText, lines);
+        ChatApiResponse apiResponse = new ChatApiResponse(iaResponseText == null ? "" : iaResponseText);
 
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/com/tesis/aike/helper/ConstantValues.java
+++ b/src/main/java/com/tesis/aike/helper/ConstantValues.java
@@ -15,11 +15,11 @@ public class ConstantValues {
         public static final String ERROR_CABINS = "Lo siento, tuve problemas para consultar la disponibilidad actual de las cabañas. Por favor, intenta de nuevo más tarde.";
         public static final String USER_NOT_IDENTIFIED_TEMPLATE = "El usuario preguntó sobre sus reservas, pero no pude identificar quién es el usuario para buscar en la base de datos. Informa amablemente al usuario que necesita iniciar sesión para poder mostrarle sus reservas. Pregunta original del usuario: \"%s\"";
         public static final String NO_RESERVATIONS = "Según nuestros registros, no tienes ninguna reserva realizada.";
-        public static final String USER_RESERVATIONS_TEMPLATE = "Según nuestros registros, estas son tus reservas:\n%s";
-        public static final String CONTEXT_RESERVATIONS_PROMPT = "Contexto de la base de datos sobre las reservas del usuario (ID: %d):\n%s\n\nPregunta del usuario: \"%s\"\n\nInstrucción: Responde a la pregunta del usuario de forma amigable y conversacional, presentando la información del contexto sobre SUS reservas. Usa SÓLO esta información. No inventes reservas ni detalles.";
+        public static final String USER_RESERVATIONS_TEMPLATE = "Según nuestros registros, tienes las siguientes reservas:\n%s";
+        public static final String CONTEXT_RESERVATIONS_PROMPT = "Contexto de la base de datos sobre las reservas del usuario (ID: %d):\n%s\n\nPregunta del usuario: \"%s\"\n\nInstrucción: Responde a la pregunta del usuario de forma amigable y conversacional, presentando la información del contexto sobre SUS reservas. Usa SÓLO esta información y redacta la respuesta como un texto corrido, sin viñetas ni enumeraciones. No inventes reservas ni detalles.";
         public static final String ERROR_RESERVATIONS = "Lo siento, tuve problemas para consultar tus reservas. Por favor, intenta de nuevo más tarde.";
         public static final String ERROR_OPENAI = "Lo siento, hubo un error al procesar tu solicitud con el asistente virtual.";
-        public static final String RESERVATION_LINE_TEMPLATE = "- Reserva número: %d | Cabaña: %s | Desde: %s | Hasta: %s | Estado: %s";
+        public static final String RESERVATION_LINE_TEMPLATE = "Reserva %d: Cabaña %s, desde %s hasta %s.";
         public static final String FALLBACK_GUIDANCE_PROMPT = """
                 El usuario ha hecho una pregunta que no parece estar relacionada con la disponibilidad de cabañas o la consulta de reservas.
                 Pregunta del usuario: "%s"

--- a/src/main/java/com/tesis/aike/model/dto/ChatApiResponse.java
+++ b/src/main/java/com/tesis/aike/model/dto/ChatApiResponse.java
@@ -1,23 +1,16 @@
 package com.tesis.aike.model.dto;
 
 public class ChatApiResponse {
-    private String respuesta;
-    private String[] lines;
+    /**
+     * Texto devuelto por la IA ya formateado para el cliente.
+     */
+    private String lines;
 
-    public ChatApiResponse(String respuesta, String[] lines) {
-        this.respuesta = respuesta;
+    public ChatApiResponse(String lines) {
         this.lines = lines;
     }
 
-    public ChatApiResponse(String respuesta) {
-        this(respuesta, respuesta == null ? new String[0] : respuesta.split("\n"));
-    }
-
-    public String getRespuesta() {
-        return respuesta;
-    }
-
-    public String[] getLines() {
+    public String getLines() {
         return lines;
     }
 }

--- a/src/main/java/com/tesis/aike/service/impl/AikeAIServiceImpl.java
+++ b/src/main/java/com/tesis/aike/service/impl/AikeAIServiceImpl.java
@@ -196,7 +196,7 @@ public class AikeAIServiceImpl implements AikeAIService {
         String lines = list.stream()
                 .map(r -> String.format(ConstantValues.AikeAIService.RESERVATION_LINE_TEMPLATE,
                         r.getId(), r.getCabin().getName(),
-                        r.getStartDate().format(DATE_TIME_FORMATTER), r.getEndDate().format(DATE_TIME_FORMATTER), r.getStatus()))
+                        r.getStartDate().format(DATE_TIME_FORMATTER), r.getEndDate().format(DATE_TIME_FORMATTER)))
                 .collect(Collectors.joining("\n"));
 
         String info = list.isEmpty()


### PR DESCRIPTION
## Summary
- remove `respuesta` field from `ChatApiResponse`
- return IA reply directly in controller
- adjust reservation templates and formatting

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687eae5f4218832eb7c44100a5e18744