### PR TITLE
Handle Mercado Pago webhooks for product purchases

### DIFF
--- a/src/main/java/com/tesis/aike/controller/ProductPaymentController.java
+++ b/src/main/java/com/tesis/aike/controller/ProductPaymentController.java
@@ -29,10 +29,8 @@ public class ProductPaymentController {
     public ResponseEntity<Void> handleWebhook(@RequestBody String rawBody) {
         try {
             Map<?, ?> body = new ObjectMapper().readValue(rawBody, Map.class);
-            if ("payment".equalsIgnoreCase((String) body.get("type"))) {
-                Long paymentId = Long.valueOf(((Map<?, ?>) body.get("data")).get("id").toString());
-                paymentService.processWebhook(paymentId);
-            }
+            Long paymentId = Long.valueOf(((Map<?, ?>) body.get("data")).get("id").toString());
+            paymentService.processWebhook(paymentId);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/tesis/aike/service/ProductPaymentService.java
+++ b/src/main/java/com/tesis/aike/service/ProductPaymentService.java
@@ -1,7 +1,6 @@
 package com.tesis.aike.service;
 
 import com.tesis.aike.model.dto.CartPaymentRequestDTO;
-import com.tesis.aike.model.dto.ProductPaymentRequestDTO;
 import com.tesis.aike.model.dto.PaymentResponseMercadoPagoDTO;
 
 public interface ProductPaymentService {


### PR DESCRIPTION
## Summary
- Configure Mercado Pago access token from environment for product payments
- Fallback to user's stored email when payer email is missing in product payment requests

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ec6375834832eab02ec50d02c1ce4