### PR TITLE
feat: verify Google login with Firebase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,9 @@
             <version>3.5.1</version>
         </dependency>
         <dependency>
-            <groupId>com.google.api-client</groupId>
-            <artifactId>google-api-client</artifactId>
-            <version>2.2.0</version>
+            <groupId>com.google.firebase</groupId>
+            <artifactId>firebase-admin</artifactId>
+            <version>9.5.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/tesis/aike/configuration/FirebaseConfig.java
+++ b/src/main/java/com/tesis/aike/configuration/FirebaseConfig.java
@@ -1,0 +1,22 @@
+package com.tesis.aike.configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+    @PostConstruct
+    public void init() throws IOException {
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.getApplicationDefault())
+                    .build();
+            FirebaseApp.initializeApp(options);
+        }
+    }
+}

--- a/src/main/java/com/tesis/aike/service/GoogleTokenVerifierService.java
+++ b/src/main/java/com/tesis/aike/service/GoogleTokenVerifierService.java
@@ -1,7 +1,7 @@
 package com.tesis.aike.service;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.firebase.auth.FirebaseToken;
 
 public interface GoogleTokenVerifierService {
-    GoogleIdToken.Payload verify(String idTokenString);
+    FirebaseToken verify(String idTokenString);
 }

--- a/src/main/java/com/tesis/aike/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/tesis/aike/service/impl/AuthServiceImpl.java
@@ -1,6 +1,6 @@
 package com.tesis.aike.service.impl;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.firebase.auth.FirebaseToken;
 import com.tesis.aike.helper.mapper.UserMapper;
 import com.tesis.aike.model.dto.RoleDTO;
 import com.tesis.aike.model.dto.UserDTO;
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -74,10 +73,10 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public Map<String, Object> loginGoogle(String idToken) {
         log.info("Iniciando proceso de login con Google.");
-        GoogleIdToken.Payload payload;
+        FirebaseToken firebaseToken;
         try {
-            payload = googleTokenVerifierService.verify(idToken);
-            if (payload == null) {
+            firebaseToken = googleTokenVerifierService.verify(idToken);
+            if (firebaseToken == null) {
                 log.error("La verificación del token de Google ha fallado.");
                 throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "ID token inválido");
             }
@@ -86,8 +85,8 @@ public class AuthServiceImpl implements AuthService {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error al verificar el token de Google.");
         }
 
-        String email = payload.getEmail();
-        String name = (String) payload.get("name");
+        String email = firebaseToken.getEmail();
+        String name = firebaseToken.getName();
         log.info("Token de Google verificado para el email: {}", email);
 
         UsersEntity user = usersRepo.findByEmail(email).orElseGet(() -> {

--- a/src/main/java/com/tesis/aike/service/impl/GoogleTokenVerifierServiceImpl.java
+++ b/src/main/java/com/tesis/aike/service/impl/GoogleTokenVerifierServiceImpl.java
@@ -1,37 +1,17 @@
 package com.tesis.aike.service.impl;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
-import com.google.api.client.googleapis.auth.oauth2.GooglePublicKeysManager;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.json.gson.GsonFactory;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseToken;
 import com.tesis.aike.service.GoogleTokenVerifierService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.util.Collections;
 
 @Service
 public class GoogleTokenVerifierServiceImpl implements GoogleTokenVerifierService {
 
-    private final GoogleIdTokenVerifier verifier;
-
-    @Autowired
-    public GoogleTokenVerifierServiceImpl(@Value("${google.oauth.client.id}") String clientId) throws Exception {
-        var transport = GoogleNetHttpTransport.newTrustedTransport();
-        var jsonFactory = GsonFactory.getDefaultInstance();
-
-        this.verifier = new GoogleIdTokenVerifier.Builder(new GooglePublicKeysManager(transport, jsonFactory))
-                .setAudience(Collections.singletonList(clientId))
-                .build();
-    }
-
     @Override
-    public GoogleIdToken.Payload verify(String idTokenString) {
+    public FirebaseToken verify(String idTokenString) {
         try {
-            GoogleIdToken idToken = verifier.verify(idTokenString);
-            return idToken != null ? idToken.getPayload() : null;
+            return FirebaseAuth.getInstance().verifyIdToken(idTokenString);
         } catch (Exception e) {
             return null;
         }


### PR DESCRIPTION
## Summary
- replace Google token verification with Firebase Auth for Google login flow
- bootstrap Firebase at startup using application default credentials
- add Firebase Admin dependency and cleanup legacy Google client

## Testing
- `mvn -q -e test` *(fails: Network is unreachable for spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_688f82c33f2c832e82f120652dfbc56c