### PR TITLE
Add cabin reservation conflict handling

### DIFF
--- a/src/main/java/com/tesis/aike/controller/ReservationsController.java
+++ b/src/main/java/com/tesis/aike/controller/ReservationsController.java
@@ -1,12 +1,15 @@
 package com.tesis.aike.controller;
 
+import com.tesis.aike.exception.CabinAlreadyReservedException;
 import com.tesis.aike.model.dto.ReservationDTO;
 import com.tesis.aike.service.ReservationService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/reservations")
@@ -28,9 +31,23 @@ public class ReservationsController {
         return ResponseEntity.ok(reservationService.findById(id));
     }
 
+    @GetMapping("/cabin/{cabinId}")
+    public ResponseEntity<List<ReservationDTO>> byCabin(@PathVariable Long cabinId) {
+        return ResponseEntity.ok(reservationService.findByCabinId(cabinId));
+    }
+
     @PostMapping
-    public ResponseEntity<ReservationDTO> create(@RequestBody ReservationDTO dto) {
-        return ResponseEntity.ok(reservationService.create(dto));
+    public ResponseEntity<?> create(@RequestBody ReservationDTO dto) {
+        try {
+            return ResponseEntity.ok(reservationService.create(dto));
+        } catch (CabinAlreadyReservedException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                    Map.of(
+                            "message", e.getMessage(),
+                            "reservations", e.getReservations()
+                    )
+            );
+        }
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/tesis/aike/exception/CabinAlreadyReservedException.java
+++ b/src/main/java/com/tesis/aike/exception/CabinAlreadyReservedException.java
@@ -1,0 +1,20 @@
+package com.tesis.aike.exception;
+
+import com.tesis.aike.helper.ConstantValues;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public class CabinAlreadyReservedException extends RuntimeException {
+    private final List<Map<String, LocalDate>> reservations;
+
+    public CabinAlreadyReservedException(List<Map<String, LocalDate>> reservations) {
+        super(ConstantValues.ReservationService.CABIN_NOT_AVAILABLE);
+        this.reservations = reservations;
+    }
+
+    public List<Map<String, LocalDate>> getReservations() {
+        return reservations;
+    }
+}

--- a/src/main/java/com/tesis/aike/helper/ConstantValues.java
+++ b/src/main/java/com/tesis/aike/helper/ConstantValues.java
@@ -87,7 +87,7 @@ public class ConstantValues {
 
     public static class ReservationService {
         public static final String NOT_FOUND = "Reserva no encontrada";
-        public static final String CABIN_NOT_AVAILABLE = "La cabaña no está disponible en las fechas solicitadas";
+        public static final String CABIN_NOT_AVAILABLE = "La cabaña ya se encuentra reservada";
         public static final String INVALID_DATA = "Datos de reserva inválidos";
     }
 

--- a/src/main/java/com/tesis/aike/security/AikeSecurity.java
+++ b/src/main/java/com/tesis/aike/security/AikeSecurity.java
@@ -48,6 +48,7 @@ public class AikeSecurity {
                         .requestMatchers(HttpMethod.GET, "/users/{id}").hasAnyRole("CLIENT", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/users/{id}").hasAnyRole("CLIENT", "ADMIN")
                         .requestMatchers(HttpMethod.GET, "/reservations/user/{userId}").hasAnyRole("CLIENT", "ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/reservations/cabin/{cabinId}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/products").permitAll()
                         .requestMatchers(HttpMethod.POST, "/reservations").hasRole("CLIENT")
 

--- a/src/main/java/com/tesis/aike/service/ReservationService.java
+++ b/src/main/java/com/tesis/aike/service/ReservationService.java
@@ -11,6 +11,7 @@ public interface ReservationService {
     void delete(Long id);
     ReservationDTO findById(Long id);
     List<ReservationDTO> findByUserId(Long userId);
+    List<ReservationDTO> findByCabinId(Long cabinId);
     List<ReservationDTO> findAll();
     void updateStatus(Long id, String status);
     boolean hasActiveReservation(Long userId);


### PR DESCRIPTION
## Summary
- return conflict details with reserved ranges when a cabin is already booked
- expose endpoint and security rule to fetch reservations by cabin
- update reservation availability message

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68928f682778832eb74431e0aacaabd9